### PR TITLE
Perform indexing concurrently

### DIFF
--- a/afind/api/index.go
+++ b/afind/api/index.go
@@ -130,10 +130,9 @@ func doIndex(s *indexServer, req afind.IndexQuery, timeout time.Duration) (
 	// Duplicate request handling: if this is a remote indexing
 	// request and we've got a recent matching Repo for that key
 	// already, save RPC bandwith and latency and return our copy.
-	r := s.repos.Get(req.Key)
-	if !local && r != nil {
+	if r := s.repos.Get(req.Key); r != nil {
 		resp.Repo = r.(*afind.Repo)
-		if missing := resp.Repo.Stale(s.cfg.TimeoutRepoStale); !missing {
+		if local || !resp.Repo.Stale(s.cfg.TimeoutRepoStale) {
 			return
 		}
 	}

--- a/afind/api/server_test.go
+++ b/afind/api/server_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/andaru/afind/afind"
@@ -12,7 +13,7 @@ func newConfig() afind.Config {
 }
 
 func eq(t *testing.T, exp, val interface{}) bool {
-	if exp != val {
+	if !reflect.DeepEqual(exp, val) {
 		t.Errorf("want %v, got %v", exp, val)
 		return false
 	}
@@ -20,7 +21,7 @@ func eq(t *testing.T, exp, val interface{}) bool {
 }
 
 func neq(t *testing.T, exp, val interface{}) bool {
-	if exp == val {
+	if reflect.DeepEqual(exp, val) {
 		t.Errorf("don't want both equal to %v", exp)
 		return false
 	}

--- a/afind/index_mock.go
+++ b/afind/index_mock.go
@@ -20,7 +20,6 @@ func (i *testIndexer) Index(ctx context.Context, req IndexQuery, ch chan *IndexR
 		Root:            "root",
 		Meta:            Meta{"foo": "bar"},
 		State:           OK,
-		NumDirs:         11,
 		NumFiles:        123,
 		SizeIndex:       ByteSize(131072),
 		SizeData:        ByteSize(1025 * 1024),

--- a/afind/repo.go
+++ b/afind/repo.go
@@ -27,12 +27,11 @@ type Repo struct {
 	State     string `json:"state"`      // Current repository indexing state
 
 	// Metadata produced during indexing
-	NumDirs   int      `json:"num_dirs"`   // Number of directories indexed
 	NumFiles  int      `json:"num_files"`  // Number of files indexed
 	SizeIndex ByteSize `json:"size_index"` // Size of index
 	SizeData  ByteSize `json:"size_data"`  // Size of the source data
 
-	// Number of shards written to disk, an optimisation to avoid a glob
+	// Number of separate index files (shards) used for this repo
 	NumShards int `json:"num_shards"`
 
 	// The time spent producing the indices for this repo

--- a/afind/repo_test.go
+++ b/afind/repo_test.go
@@ -46,7 +46,11 @@ func TestRepoSetup(t *testing.T) {
 	ir.Dirs = []string{"dir1", "dir2"}
 	ir.Root = "/"
 	ir.Meta["key"] = "value"
-	ir.Meta["host"] = "abc"
+	// should have the same sort of effect as
+	ir.Meta["host"] = "xyz"
+	// should change the value above, referred to by
+	// Repo.Host/Repo.Meta.Host()
+	ir.Meta.SetHost("abc")
 	r2 := newRepoFromQuery(&ir, "/")
 
 	if r1.Host() != "" || r2.Host() != "abc" {
@@ -58,6 +62,25 @@ func TestRepoSetup(t *testing.T) {
 	if len(shards) != 2 {
 		t.Error("got", len(shards), "shards, want 2")
 	}
+}
+
+func TestRepoSetMeta(t *testing.T) {
+	defaults := Meta{"host": "defaulthost"}
+	r1 := NewRepo()
+	r1.Meta.SetHost("abc") // will be replaced by defaulthost
+	r1.Meta["foo"] = "bar"
+
+	// host below is replacing abc
+	reqMeta := Meta{"project": "foo", "host": "final"}
+
+	r1.SetMeta(defaults, reqMeta)
+	if len(r1.Meta) != 3 {
+		t.Error("want 3 keys in Meta, got", r1.Meta)
+	}
+	eq(t, "bar", r1.Meta["foo"])
+	eq(t, "final", r1.Meta.Host())
+	eq(t, "final", r1.Host())
+	eq(t, "foo", r1.Meta["project"])
 }
 
 func TestRepoJson(t *testing.T) {

--- a/afind/repo_test.go
+++ b/afind/repo_test.go
@@ -91,7 +91,6 @@ func TestRepoJson(t *testing.T) {
 	r.IndexPath = "indexpath"
 	r.SetHost("m123.foo")
 	r.State = INDEXING
-	r.NumDirs = 22
 	r.NumFiles = 33
 	r.NumShards = 6
 
@@ -123,7 +122,6 @@ func TestRepoJson(t *testing.T) {
 	eq(t, "m123.foo", newr.Host())
 	eq(t, "INDEXING", newr.State)
 	eq(t, "key", newr.Key)
-	eq(t, 22, newr.NumDirs)
 	eq(t, 33, newr.NumFiles)
 	eq(t, 6, newr.NumShards)
 }

--- a/cmd/afind/afind.go
+++ b/cmd/afind/afind.go
@@ -234,14 +234,14 @@ func repoAsString(r *afind.Repo) string {
 	meta = meta[:len(meta)-2] + "}"
 
 	return (fmt.Sprintf("repo: %s [%s]\n", r.Key, r.State) +
-		fmt.Sprintf("  last updated:  %v\n", r.TimeUpdated) +
-		fmt.Sprintf("  indexing time: %v\n", r.ElapsedIndexing) +
-		fmt.Sprintf("  state:         %s\n", r.State) +
-		fmt.Sprintf("  root path:     %v\n", r.Root) +
-		fmt.Sprintf("  data size:     %s\n", r.SizeData) +
-		fmt.Sprintf("  index size:    %s\n", r.SizeIndex) +
-		fmt.Sprintf("  files/dirs:    %d/%d\n", r.NumFiles, r.NumDirs) +
-		fmt.Sprintf("  metadata:      %v\n", meta))
+		fmt.Sprintf("  last updated: %v\n", r.TimeUpdated) +
+		fmt.Sprintf("  indexed in:   %v\n", r.ElapsedIndexing) +
+		fmt.Sprintf("  state:        %s\n", r.State) +
+		fmt.Sprintf("  root path:    %v\n", r.Root) +
+		fmt.Sprintf("  data size:    %s\n", r.SizeData) +
+		fmt.Sprintf("  index size:   %s\n", r.SizeIndex) +
+		fmt.Sprintf("  files:        %d\n", r.NumFiles) +
+		fmt.Sprintf("  metadata:     %v\n", meta))
 }
 
 func repos(c *ctx, key string) error {

--- a/utils/math.go
+++ b/utils/math.go
@@ -1,0 +1,17 @@
+package utils
+
+// MinInt returns the minimum of two ints
+func MinInt(l, r int) int {
+	if l > r {
+		return r
+	}
+	return l
+}
+
+// MinInt returns the maximum of two ints
+func MaxInt(l, r int) int {
+	if l < r {
+		return r
+	}
+	return l
+}


### PR DESCRIPTION
- Index each of the index shards in a concurrent goroutine
- Count number of files/directories differently due to concurrent
  refactoring. As a result, remove count of directories from the Repo
  datastructure.
- Use interfaces to allow for easier testing of the indexing code
